### PR TITLE
#160583994 Users should receive descriptive signup/Registration validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ db.sqlite3
 
 #vscode
 .vscode
+
+#DS store
+.DS_Store

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -20,11 +20,6 @@ class UserManager(BaseUserManager):
 
     def create_user(self, username, email, password=None):
         """Create and return a `User` with an email, username and password."""
-        if username is None:
-            raise TypeError('Users must have a username.')
-
-        if email is None:
-            raise TypeError('Users must have an email address.')
 
         user = self.model(username=username, email=self.normalize_email(email))
         user.set_password(password)
@@ -54,13 +49,13 @@ class User(AbstractBaseUser, PermissionsMixin):
     # Each `User` needs a human-readable unique identifier that we can use to
     # represent the `User` in the UI. We want to index this column in the
     # database to improve lookup performance.
-    username = models.CharField(db_index=True, max_length=255, unique=True)
+    username = models.CharField(db_index=True, max_length=255, unique=True, blank=True)
 
     # We also need a way to contact the user and a way for the user to identify
     # themselves when logging in. Since we need an email address for contacting
     # the user anyways, we will also use the email for logging in because it is
     # the most common form of login credential at the time of writing.
-    email = models.EmailField(db_index=True, unique=True)
+    email = models.EmailField(db_index=True, unique=True, blank=True)
 
     # When a user no longer wishes to use our platform, they may try to delete
     # there account. That's a problem for us because the data we collect is

--- a/authors/apps/authentication/renderers.py
+++ b/authors/apps/authentication/renderers.py
@@ -16,10 +16,14 @@ class UserJSONRenderer(JSONRenderer):
         if errors is not None:
             # As mentioned about, we will let the default JSONRenderer handle
             # rendering errors.
-            return super(UserJSONRenderer, self).render(data)
+            # return super(UserJSONRenderer, self).render(data)
+            return json.dumps({
+                'errors': errors
+            })
 
 
         # Finally, we can render our data under the "user" namespace.
         return json.dumps({
+            'message' : 'User successfully registered',
             'user': data
         })

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -16,9 +16,6 @@ class RegistrationSerializer(serializers.ModelSerializer):
         write_only=True
     )
 
-    # The client should not be able to send a token along with a registration
-    # request. Making `token` read-only handles that for us.
-
     class Meta:
         model = User
         # List all of the fields that could possibly be included in a request

--- a/authors/apps/authentication/tests/__init__.py
+++ b/authors/apps/authentication/tests/__init__.py
@@ -17,8 +17,43 @@ class BaseTest(TestCase):
             "email":"test@test.com",
             "password":"testpassword"}
         }
-        self.reg_data_no_username= {"user": {
+
+        self.missing_username= {
+            "user": {
             "username":"",
             "email":"test@test.com",
-            "password":"testpassword"}
+            "password":"test_password"
+            }
         }
+
+        self.missing_email= {
+            "user": {
+            "username":"test",
+            "email":"",
+            "password":"test_password"
+            }
+        }
+
+        self.invalid_email= {
+            "user": {
+            "username":"test",
+            "email":"test",
+            "password":"test_password"
+            }
+        }
+
+        self.short_password= {
+            "user": {
+            "username":"test",
+            "email":"test@test.com",
+            "password":"test"
+            }
+        }
+
+        self.non_alphanumeric_password= {
+            "user": {
+            "username":"test",
+            "email":"test@test.com",
+            "password":"@$* p#$%"
+            }
+        }   

--- a/authors/apps/authentication/tests/test_user.py
+++ b/authors/apps/authentication/tests/test_user.py
@@ -18,4 +18,47 @@ class TestUser(BaseTest):
         response = self.client.post("/api/users/login/", self.login_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn(self.login_data['user']['email'],response.data['email'])
-        assert "token" in response.data     
+        assert "token" in response.data    
+
+    def test_registration_without_username(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup without a username"""
+        response = self.client.post("/api/users/", self.missing_username, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('A username is required to signup', response.json()['errors']['username'])
+
+    def test_registration_with_existing_user_email(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup with an existing email address"""
+        self.client.post("/api/users/", self.reg_data, format="json")
+        response = self.client.post("/api/users/", self.reg_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('user with this email already exists.', response.json()['errors']['email'])
+
+    def test_registration_with_invalid_email(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup with an invalid email address"""
+        response = self.client.post("/api/users/", self.invalid_email, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('A valid email address is required to signup', response.json()['errors']['email'])
+
+    def test_registration_without_email(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup with an invalid email address"""
+        response = self.client.post("/api/users/", self.missing_email, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('An email address is required to signup', response.json()['errors']['email'])
+
+    def test_registration_with_short_password(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup with a password of length less than 8"""
+        response = self.client.post("/api/users/", self.short_password, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Password should be atleast 8 characters long', response.json()['errors']['password'])
+
+    def test_registration_with_non_alphanumeric_password(self):
+        """This method tests that a user receives a descriptive error message 
+        when they attempt to signup with a non-alphanumeric password"""
+        response = self.client.post("/api/users/", self.non_alphanumeric_password, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('Password should only contain numbers and letters', response.json()['errors']['password'])

--- a/authors/apps/authentication/validation.py
+++ b/authors/apps/authentication/validation.py
@@ -1,0 +1,32 @@
+import re
+from rest_framework import serializers
+
+def validate(data):
+    """This method validates username and password"""
+    username = str(data.get('username', None)).strip()
+    email = data.get('email', None)
+    password = data.get('password', None)
+        
+    if not username:
+        raise serializers.ValidationError({'username': 'A username is required to signup'})
+
+    if not email:
+        raise serializers.ValidationError({'email': 'An email address is required to signup'})
+
+    if not re.search("^[a-z0-9_.+-]+@[a-z]+\\.[a-z]+$",email):
+        raise serializers.ValidationError({'email': 'A valid email address is required to signup'})
+
+    if not password:
+        raise serializers.ValidationError({'password': 'A password is required to signup'})
+
+    if not re.match("^[A-Za-z0-9]*$", password):
+        raise serializers.ValidationError({'password': 'Password should only contain numbers and letters'})
+
+    if len(password) < 8 :
+        raise serializers.ValidationError({'password': 'Password should be atleast 8 characters long'})
+
+    return {
+            "username" : username,
+            "email" : email,
+            "password": password
+        }

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -3,12 +3,12 @@ from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from .validation import validate
 
 from .renderers import UserJSONRenderer
 from .serializers import (
     LoginSerializer, RegistrationSerializer, UserSerializer
 )
-
 
 class RegistrationAPIView(APIView):
     # Allow any user (authenticated or not) to hit this endpoint.
@@ -18,6 +18,7 @@ class RegistrationAPIView(APIView):
 
     def post(self, request):
         user = request.data.get('user', {})
+        validate(user)
 
         # The create serializer, validate serializer, save serializer pattern
         # below is common and you will see it a lot throughout this course and


### PR DESCRIPTION
**What does this PR do?**
This PR provides descriptive error messages for invalid user data on registration

**Description of the task to be completed**
Have the following descriptive messages when a user enters invalid data on registration.


|Parameter|Descriptive error message|
|-----------|----------------------------|
|Existing user email|User with this email already exists.|
|Invalid email|Enter a valid email address.|
|Password of length less than 8 characters|Password should be at least 8 characters long|
|Password not being alphanumeric|Password should only contain numbers and letters|


**How should this be tested?**

After cloning the repo, checkout ft-signup-validation-160583994 branch, run the server and test this endpoint on Postman

`POST /api/users/`
{"user":{"username"username" : "", "email": "email", "password": "password"}}


**Screenshots** 

Existing user email 

<img width="1166" alt="screen shot 2018-09-27 at 12 17 30" src="https://user-images.githubusercontent.com/31965597/46136083-75d68c80-c24f-11e8-9f65-d6b9042dbd96.png">

Invalid email

<img width="1163" alt="screen shot 2018-09-27 at 12 24 25" src="https://user-images.githubusercontent.com/31965597/46136461-52f8a800-c250-11e8-893e-97779fa2ac96.png">


Password of length less than 8 characters

<img width="1166" alt="screen shot 2018-09-27 at 12 19 47" src="https://user-images.githubusercontent.com/31965597/46136330-06ad6800-c250-11e8-8d55-e9d573ceba85.png">

Password not being alphanumeric

<img width="1166" alt="screen shot 2018-09-27 at 12 20 20" src="https://user-images.githubusercontent.com/31965597/46136246-d5cd3300-c24f-11e8-98d0-720a74375f0b.png">

Run tests

<img width="1433" alt="screen shot 2018-09-27 at 17 33 13" src="https://user-images.githubusercontent.com/31965597/46153390-bb10b380-c27b-11e8-9035-a0fef8842d09.png">

#160583994