### PR TITLE
#160918236 clean up develop

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
@@ -39,7 +39,7 @@ STATICFILES_DIRS = (
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-ALLOWED_HOSTS = ['ah-backend-stark-staging.herokuapp.com', 'ah-backend-stark.herokuapp.com', 'localhost', 'http://127.0.0.1:8000/']
+ALLOWED_HOSTS = ['ah-backend-stark-staging.herokuapp.com', 'ah-backend-stark.herokuapp.com', 'localhost', '127.0.0.1']
 
 # Application definition
 


### PR DESCRIPTION
#### What does this PR do?
reverts the settings file back to the way it was originally
#### Description of Task to be completed?
 - reverts the settings back to a single file rather than a folder with different versions of settings for the development and production environments
 - add localhost to ALLOWED_HOSTS
#### How should this be manually tested?
After cloning the repo and cd into it
 - you may check out the file structure in the authors app
 - when running the app locally, django-heroku MUST NOT be activated. To achieve this, lines 160 - 162 in authors/settings.py must be commented out, otherwise, the app will not run on localhost
 - test the endpoints in postman using the url: http://127.0.0.1:8000/
#### Any background context you want to provide?
 - change debug to true in authors/settings.py for easy debugging, when running it locally
#### What are the relevant pivotal tracker stories?
#160918236