### PR TITLE
users should like and dislike articles 

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -183,4 +183,18 @@ class Article(models.Model):
     def __str__(self):
         return self.title
 
+    def likes(self):
+        likes = Likes.objects.all().filter(article_id=self.id, action = True).count()
+        return likes
+
+    def dislikes(self):
+        dislikes = Likes.objects.all().filter(article_id=self.id, action = False).count()
+        return dislikes    
+
+class Likes(models.Model):
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    action_by = models.ForeignKey(User, on_delete=models.CASCADE)
+    action  = models.BooleanField()
+    action_at = models.DateTimeField(auto_now_add=True)       
+
 

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -13,3 +13,15 @@ class ArticleJSONRenderer(JSONRenderer):
             return super(ArticleJSONRenderer, self).render(data)
 
         return json.dumps({'article':data})
+
+class LikesJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self,data, media_type=None, render_context=None):
+
+        errors = data.get('errors',None)
+
+        if errors:
+            return super(LikesJSONRenderer, self).render(data)
+
+        return json.dumps({'status':data})

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Article
+from .models import Article,Likes
 from authors.apps.authentication.backends import JWTAuthentication
 from ast import literal_eval
 
@@ -18,7 +18,7 @@ class ArticlesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = ("slug","title", "description", "body",
-         "tagList","createdAt","updatedAt","favorited","favoritesCount", "rating", "ratingsCount", "author")
+         "tagList","createdAt","updatedAt","favorited","favoritesCount", "rating", "ratingsCount", "author","likes", "dislikes")
 
     @staticmethod
     def convert_tagList_to_str(request_data={}):
@@ -38,3 +38,13 @@ class ArticlesSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+class LikeSerializer(serializers.ModelSerializer):
+    username = serializers.ReadOnlyField(source='action_by.username')
+    article = serializers.ReadOnlyField(source='article.slug')
+
+    class Meta:
+        model = Likes
+        fields=("username","action","article")   
+
+

--- a/authors/apps/articles/tests/test_article.py
+++ b/authors/apps/articles/tests/test_article.py
@@ -133,3 +133,41 @@ class TestArticle(BaseTest):
         self.assertEqual(get_response.status_code,status.HTTP_200_OK)
         self.assertEqual(data.get('rating'), 0)
         self.assertEqual(data.get('ratingsCount'), 0)
+
+    def test_liking_articles(self):
+        """This method tests for liking an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response = self.client.post("/api/articles/titlely/like/", self.like_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert "username" in response.data
+        assert "action" in response.data
+        assert "article" in response.data 
+
+    def test_updating_disliking_articles(self):
+        """This method tests for updating liking an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response = self.client.post("/api/articles/titlely/like/", self.like_article, format="json")
+        response = self.client.put('/api/articles/titlely/like/', self.dislike_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert "username" in response.data
+        assert "action" in response.data
+        assert "article" in response.data
+
+    def test_liking_article_twice(self):
+        """This method tests for updating liking an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response = self.client.post("/api/articles/titlely/like/", self.like_article, format="json")
+        response1 = self.client.post('/api/articles/titlely/like/', self.dislike_article, format="json")
+        self.assertEqual(response1.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "errors" in response1.data
+
+    def test_updating_liking_article_without_liking_first(self):
+        """This method tests for updating liking an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response1 = self.client.put('/api/articles/titlely/like/', self.dislike_article, format="json")
+        self.assertEqual(response1.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "errors" in response1.data             

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import ArticleCreationAPIView, GetSingleArticleAPIView, RateArticleAPIView
+from .views import ArticleCreationAPIView, GetSingleArticleAPIView, RateArticleAPIView, LikeView #, UpdateLike
 
 urlpatterns = [
     path('articles/',ArticleCreationAPIView.as_view()),
     path('articles/<str:slug>',GetSingleArticleAPIView.as_view()),
-    path('articles/<str:slug>/rate_article/',RateArticleAPIView.as_view())
+    path('articles/<str:slug>/rate_article/',RateArticleAPIView.as_view()),
+    path('articles/<str:slug>/like/',LikeView.as_view()),
 ]

--- a/authors/apps/authentication/tests/__init__.py
+++ b/authors/apps/authentication/tests/__init__.py
@@ -132,6 +132,14 @@ class BaseTest(TestCase):
             "rating": 6
                 }
         }
+        self.like_article = {"like":{
+	        "action":1
+                }
+        }
+        self.dislike_article = {"like":{
+	        "action":0
+                }
+        }
 
         self.user_email = {"user": {
             "email":"test@test.com"


### PR DESCRIPTION
**What does this PR do**
This PR enables authenticated users to like or dislike an article.

**Description of the task to be completed**
With this task, authenticated users are able to like or dislike an article. Users are also able to update their status and turn a like into a dislike.

**How to test it manually**
Get an article slug and got to the route http://127.0.0.1:8000/api/articles/slug-here/like/  .You will be able to like or dislike an article. 
                   ``` {
                               "like":{
	                                  "action":1
                                         }
                   }```
A user can input 1 for like and 0 for dislike because it's a boolean field.
A user is able to update the like status on an article by changing the method to PUT

A User is able to see the number of likes or dislikes on articles by heading to the get articles URL 
http://127.0.0.1:8000/api/articles/ 



**Screen shots**
<img width="1009" alt="screen shot 2018-10-15 at 12 07 43" src="https://user-images.githubusercontent.com/40117122/46941201-49a27480-d073-11e8-9de3-1c418cb10515.png">

<img width="1036" alt="screen shot 2018-10-15 at 12 08 06" src="https://user-images.githubusercontent.com/40117122/46941214-51faaf80-d073-11e8-8c2f-75aa3b88dca7.png">

