### PR TITLE
#160583992 add documentation

### DIFF
--- a/authors/apps/articles/migrations/0001_initial.py
+++ b/authors/apps/articles/migrations/0001_initial.py
@@ -17,9 +17,15 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Article',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id',
+                 models.AutoField(
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     verbose_name='ID')),
                 ('title', models.CharField(max_length=255)),
-                ('slug', models.SlugField(blank=True, max_length=255, unique=True)),
+                ('slug',
+                 models.SlugField(blank=True, max_length=255, unique=True)),
                 ('description', models.CharField(max_length=500)),
                 ('body', models.TextField()),
                 ('tagList', models.CharField(blank=True, max_length=2000)),
@@ -28,7 +34,10 @@ class Migration(migrations.Migration):
                 ('updatedAt', models.DateTimeField(auto_now_add=True)),
                 ('rating', models.FloatField(default=0)),
                 ('ratingsCount', models.IntegerField(default=0)),
-                ('author', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('author',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'ordering': ['createdAt'],
@@ -37,12 +46,28 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Comment',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id',
+                 models.AutoField(
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     verbose_name='ID')),
                 ('body', models.TextField()),
                 ('timestamp', models.DateTimeField(auto_now_add=True)),
-                ('article', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='articles.Article')),
-                ('parent_comment', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='articles.Comment')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('article',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to='articles.Article')),
+                ('parent_comment',
+                 models.ForeignKey(
+                     blank=True,
+                     null=True,
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to='articles.Comment')),
+                ('user',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'ordering': ['timestamp'],
@@ -51,20 +76,42 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Favourite',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id',
+                 models.AutoField(
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
-                ('article', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='articles.Article')),
-                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                ('article',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to='articles.Article')),
+                ('user',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.CreateModel(
             name='Likes',
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('id',
+                 models.AutoField(
+                     auto_created=True,
+                     primary_key=True,
+                     serialize=False,
+                     verbose_name='ID')),
                 ('action', models.BooleanField()),
                 ('action_at', models.DateTimeField(auto_now_add=True)),
-                ('action_by', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
-                ('article', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='articles.Article')),
+                ('action_by',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to=settings.AUTH_USER_MODEL)),
+                ('article',
+                 models.ForeignKey(
+                     on_delete=django.db.models.deletion.CASCADE,
+                     to='articles.Article')),
             ],
         ),
     ]

--- a/authors/apps/articles/mixins.py
+++ b/authors/apps/articles/mixins.py
@@ -1,5 +1,4 @@
 class AhPaginationMixin(object):
-
     @property
     def paginator(self):
         """

--- a/authors/apps/authentication/tests/__init__.py
+++ b/authors/apps/authentication/tests/__init__.py
@@ -159,6 +159,10 @@ class BaseTest(TestCase):
                 "description": "The description is also different"
             }
         }
+        self.like_article = {"like": {"action": 1}}
+        self.dislike_article = {"like": {"action": 0}}
+
+        self.user_email = {"user": {"email": "test@test.com"}}
 
         self.article_rating_4 = {"article": {"rating": 4}}
 

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from django.urls import path, include
 from django.contrib import admin
+from rest_framework.documentation import include_docs_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('authors.apps.authentication.urls')),
     path('api/', include('authors.apps.profiles.urls')),
     path('api/', include('authors.apps.articles.urls')),
+    path('coreapi-docs/', include_docs_urls(title="Author's Haven Stark"))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asn1crypto==0.24.0
 certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
+coreapi==2.3.3
 coverage==4.5.1
 coveralls==1.5.0
 cryptography==2.3.1


### PR DESCRIPTION
#### What does this PR do?
adds coreapi documentation to explain api features
#### How should this be manually tested?
when running the application on localhost:
- visit `http://127.0.0.1:8000/coreapi-docs/`
#### Any background context you want to provide?
- the codebase needs to be modified to display more information
#### What are the relevant pivotal tracker stories?
#160583992
#### Screenshots (if appropriate)
Documentation page
![image](https://user-images.githubusercontent.com/40589388/47096442-de55cf80-d237-11e8-80df-e4236ef467a7.png)

Documentation response when user is activated
![image](https://user-images.githubusercontent.com/40589388/47096500-ff1e2500-d237-11e8-98d1-9713852d1ff4.png)
