### PR TITLE
users should favourite articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ var/
 .vscode/
 
 # Django Migrations
-migrations/
-authors/apps/articles/migrations
+migrations/*
 authors/apps/authentication/migrations/*
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -103,6 +102,3 @@ db.sqlite3
 
 #DS store
 .DS_Store
-
-# migrations folder and files
-migrations

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -19,8 +19,6 @@ class Article(models.Model):
     image = models.URLField(blank=True)
     createdAt = models.DateTimeField(auto_now_add=True)
     updatedAt = models.DateTimeField(auto_now_add=True)
-    favorited = models.BooleanField(default=False)
-    favoritesCount = models.IntegerField(default=0)
     rating = models.FloatField(default=0)
     ratingsCount = models.IntegerField(default=0)
     author = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -201,6 +199,11 @@ class Article(models.Model):
             article_id=self.id, action=False).count()
         return dislikes
 
+    def favoritesCount(self):
+        favourite = Favourite.objects.all().filter(
+            article=self.id).count()
+        return favourite
+
 
 class Likes(models.Model):
     article = models.ForeignKey(Article, on_delete=models.CASCADE)
@@ -233,3 +236,12 @@ class Comment(models.Model):
         if self.parent_comment is not None:
             return False
         return True
+
+
+class Favourite(models.Model):
+    article = models.ForeignKey(Article, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.article.slug

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Article, Likes, Comment
+from .models import Article, Likes, Comment, Favourite
 from authors.apps.authentication.backends import JWTAuthentication
 from ast import literal_eval
 
@@ -17,11 +17,9 @@ class ArticlesSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Article
-        fields = (
-            "slug", "title", "description", "body", "image",
-            "tagList", "createdAt", "updatedAt", "favorited",
-            "favoritesCount", "rating", "ratingsCount", "author",
-            "likes", "dislikes")
+        fields = ("slug", "title", "description", "body", "image", "tagList",
+                  "createdAt", "updatedAt", "favoritesCount", "rating",
+                  "ratingsCount", "author", "likes", "dislikes")
 
     @staticmethod
     def convert_tagList_to_str(request_data={}):
@@ -78,3 +76,28 @@ class CommentDetailSerializer(serializers.ModelSerializer):
         if obj.is_parent:
             return ChildCommentSerializer(obj.children(), many=True).data
         return None
+
+
+class FavouriteSerializer(serializers.ModelSerializer):
+    """This serializer class handles favourites """
+
+    username = serializers.ReadOnlyField(source='user.username')
+    article = serializers.ReadOnlyField(source='article.slug')
+
+    class Meta:
+        """Favourite serializer meta class"""
+        model = Favourite
+        fields = ("username", "article")
+
+
+class GetFavouriteSerializer(serializers.ModelSerializer):
+    """This serializer class handles getting favourites"""
+
+    title = serializers.CharField(source='article.title')
+    slug = serializers.CharField(source='article.slug')
+    description = serializers.CharField(source='article.description')
+
+    class Meta:
+        """get favourite serializer meta class"""
+        model = Favourite
+        fields = ("title", "slug", "description")

--- a/authors/apps/articles/tests/test_article.py
+++ b/authors/apps/articles/tests/test_article.py
@@ -11,8 +11,7 @@ class TestArticle(BaseTest):
         self.mock_login()
         response = self.client.post(
             '/api/articles/', self.article_1, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn('Titlely', response.data['title'])
         self.assertIn('This is my article', response.data['body'])
 
@@ -20,8 +19,7 @@ class TestArticle(BaseTest):
         self.mock_login()
         response = self.client.post(
             '/api/articles/', self.invalid_article, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_get_all_articles(self):
         response = self.client.get('/api/articles/')
@@ -32,26 +30,22 @@ class TestArticle(BaseTest):
 
     def test_get_single_article(self):
         self.mock_login()
-        self.client.post(
-            '/api/articles/', self.article_1, format="json")
+        self.client.post('/api/articles/', self.article_1, format="json")
         response = self.client.get('/api/articles/titlely')
         data = response.data
         self.assertEqual(response.status_code, 200)
         self.assertTrue('article' in data)
 
     def test_getting_innexistent_article(self):
-        response = self.client.get(
-            '/api/articles/brave-new-world-556')
+        response = self.client.get('/api/articles/brave-new-world-556')
         self.assertEqual(response.status_code, 404)
 
     def test_duplication_of_title_by_same_user(self):
         self.mock_login()
-        self.client.post(
-            '/api/articles/', self.article_1, format="json")
+        self.client.post('/api/articles/', self.article_1, format="json")
         response = self.client.post(
             '/api/articles/', self.article_1, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
             response.data.get('errors')[0],
             "You already have an article with the same title")
@@ -60,44 +54,35 @@ class TestArticle(BaseTest):
         self.different_user_mock_login()
         response = self.client.post(
             '/api/articles/', self.article_1, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIn('Titlely', response.data['title'])
 
     def test_deletion_of_article_by_owner(self):
         self.mock_login()
-        self.client.post(
-            '/api/articles/', self.article_1, format="json")
-        response = self.client.delete(
-            '/api/articles/titlely')
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK)
+        self.client.post('/api/articles/', self.article_1, format="json")
+        response = self.client.delete('/api/articles/titlely')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data.get('message'), "Article deleted successfully")
 
     def test_deletion_of_article_by_non_owner(self):
         self.mock_login()
-        self.client.post(
-            '/api/articles/', self.article_1, format="json")
+        self.client.post('/api/articles/', self.article_1, format="json")
         self.different_user_mock_login()
         response = self.client.delete('/api/articles/titlely')
-        self.assertEqual(
-            response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertIn(
-            'You do not have rights to delete', response.data.get('message'))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('You do not have rights to delete',
+                      response.data.get('message'))
 
     def test_update_of_article_by_owner(self):
         self.mock_login()
-        self.client.post(
-            '/api/articles/', self.article_1, format="json")
+        self.client.post('/api/articles/', self.article_1, format="json")
         edit_response = self.client.put(
             '/api/articles/titlely', self.modified_article, format="json")
         get_response = self.client.get('/api/articles/modified-title')
         data = get_response.data.get('article')
-        self.assertEqual(
-            edit_response.status_code, status.HTTP_202_ACCEPTED)
-        self.assertEqual(
-            get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(edit_response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         self.assertEqual(data.get('title'), "Modified title")
         self.assertEqual(
             data.get('description'), "The description is also different")
@@ -108,54 +93,52 @@ class TestArticle(BaseTest):
         self.different_user_mock_login()
         rating_response = self.client.put(
             '/api/articles/titlely/rate_article/',
-            self.article_rating_4, format="json")
+            self.article_rating_4,
+            format="json")
         get_response = self.client.get('/api/articles/titlely')
         data = get_response.data.get('article')
 
-        self.assertEqual(
-            rating_response.status_code, status.HTTP_202_ACCEPTED)
-        self.assertEqual(
-            get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rating_response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         self.assertEqual(data.get('rating'), 4)
         self.assertEqual(data.get('ratingsCount'), 1)
 
     def test_rating_score_is_average_of_all_ratings(self):
         self.mock_login()
-        self.client.post(
-            "/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/", self.article_1, format="json")
         self.different_user_mock_login()
         rating_response_1 = self.client.put(
             '/api/articles/titlely/rate_article/',
-            self.article_rating_4, format="json")
+            self.article_rating_4,
+            format="json")
         rating_response_2 = self.client.put(
             '/api/articles/titlely/rate_article/',
-            self.article_rating_5, format="json")
+            self.article_rating_5,
+            format="json")
         get_response = self.client.get('/api/articles/titlely')
         data = get_response.data.get('article')
 
-        self.assertEqual(
-            rating_response_1.status_code, status.HTTP_202_ACCEPTED)
-        self.assertEqual(
-            rating_response_2.status_code, status.HTTP_202_ACCEPTED)
-        self.assertEqual(
-            get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rating_response_1.status_code,
+                         status.HTTP_202_ACCEPTED)
+        self.assertEqual(rating_response_2.status_code,
+                         status.HTTP_202_ACCEPTED)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         self.assertEqual(data.get('rating'), 4.5)
         self.assertEqual(data.get('ratingsCount'), 2)
 
     def test_user_rates_own_article(self):
         self.mock_login()
-        self.client.post(
-            "/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/", self.article_1, format="json")
         rating_response = self.client.put(
             '/api/articles/titlely/rate_article/',
-            self.article_rating_4, format="json")
+            self.article_rating_4,
+            format="json")
         get_response = self.client.get('/api/articles/titlely')
         data = get_response.data.get('article')
 
-        self.assertEqual(
-            rating_response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rating_response.status_code,
+                         status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         self.assertEqual(data.get('rating'), 0)
         self.assertEqual(data.get('ratingsCount'), 0)
 
@@ -165,27 +148,24 @@ class TestArticle(BaseTest):
         self.different_user_mock_login()
         rating_response = self.client.put(
             '/api/articles/titlely/rate_article/',
-            self.article_rating_6, format="json")
+            self.article_rating_6,
+            format="json")
         get_response = self.client.get('/api/articles/titlely')
         data = get_response.data.get('article')
 
-        self.assertEqual(
-            rating_response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(
-            get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(rating_response.status_code,
+                         status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         self.assertEqual(data.get('rating'), 0)
         self.assertEqual(data.get('ratingsCount'), 0)
 
     def test_liking_articles(self):
         """This method tests for liking an article"""
         self.mock_login()
-        self.client.post(
-            "/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/", self.article_1, format="json")
         response = self.client.post(
-            "/api/articles/titlely/like/",
-            self.like_article, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_201_CREATED)
+            "/api/articles/titlely/like/", self.like_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         assert "username" in response.data
         assert "action" in response.data
         assert "article" in response.data
@@ -193,16 +173,12 @@ class TestArticle(BaseTest):
     def test_updating_disliking_articles(self):
         """This method tests for updating liking an article"""
         self.mock_login()
-        self.client.post(
-            "/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/", self.article_1, format="json")
         response = self.client.post(
-            "/api/articles/titlely/like/",
-            self.like_article, format="json")
+            "/api/articles/titlely/like/", self.like_article, format="json")
         response = self.client.put(
-            '/api/articles/titlely/like/',
-            self.dislike_article, format="json")
-        self.assertEqual(
-            response.status_code, status.HTTP_200_OK)
+            '/api/articles/titlely/like/', self.dislike_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         assert "username" in response.data
         assert "action" in response.data
         assert "article" in response.data
@@ -255,3 +231,50 @@ class TestArticle(BaseTest):
                                     }
                                     }, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_favouriting_article(self):
+        """This method tests favourating an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response = self.client.post(
+            "/api/articles/titlely/favourite/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert "message" in response.data
+
+    def test_getting_favourite_articles(self):
+        """This method tests favourating an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/titlely/favourite/", format="json")
+        response = self.client.get("/api/articles/favourites/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert "favourites" in response.data
+
+    def test_favouriting_article_twice(self):
+        """This method tests favourating an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/titlely/favourite/", format="json")
+        response = self.client.post(
+            "/api/articles/titlely/favourite/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "errors" in response.data
+
+    def test_unfavouriting_article(self):
+        """This method tests favourating an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        self.client.post("/api/articles/titlely/favourite/", format="json")
+        response = self.client.delete(
+            "/api/articles/titlely/favourite/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        assert "status" in response.data
+
+    def test_unfavouriting_article_not_favourated(self):
+        """This method tests favourating an article"""
+        self.mock_login()
+        self.client.post("/api/articles/", self.article_1, format="json")
+        response = self.client.delete(
+            "/api/articles/titlely/favourite/", format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        assert "error" in response.data

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
 
-from .views import (
-    ArticleCreationAPIView, GetSingleArticleAPIView,
-    PostCommentApiView, CommentDetailApiView, RateArticleAPIView, LikeView
-)
+from .views import (ArticleCreationAPIView, GetSingleArticleAPIView,
+                    PostCommentApiView, CommentDetailApiView,
+                    RateArticleAPIView, LikeView)
+from .views_favourites import (FavouriteView, GetFavouriteView)
 urlpatterns = [
     path('articles/', ArticleCreationAPIView.as_view()),
     path('articles/<str:slug>', GetSingleArticleAPIView.as_view()),
@@ -12,5 +12,6 @@ urlpatterns = [
          CommentDetailApiView.as_view()),
     path('articles/<str:slug>/rate_article/', RateArticleAPIView.as_view()),
     path('articles/<str:slug>/like/', LikeView.as_view()),
-
+    path('articles/<str:slug>/favourite/', FavouriteView.as_view()),
+    path('articles/favourites/', GetFavouriteView.as_view()),
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,26 +1,21 @@
 from rest_framework import status, serializers, exceptions
-from rest_framework.permissions import (
-    IsAuthenticatedOrReadOnly, IsAuthenticated
-)
+from rest_framework.permissions import (IsAuthenticatedOrReadOnly,
+                                        IsAuthenticated)
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.shortcuts import get_object_or_404
-from rest_framework.generics import (
-    UpdateAPIView, CreateAPIView, UpdateAPIView
-)
-
+from rest_framework.generics import (UpdateAPIView, CreateAPIView,
+                                     RetrieveAPIView)
 from .renderers import ArticleJSONRenderer, LikesJSONRenderer
-from .serializers import (
-    ArticlesSerializer, CommentSerializer,
-    CommentDetailSerializer, LikeSerializer
-)
+from .serializers import (ArticlesSerializer, CommentSerializer,
+                          CommentDetailSerializer, LikeSerializer)
 from .models import Article, Comment, Likes
 from authors.apps.authentication.backends import JWTAuthentication
 from django.shortcuts import get_object_or_404
 
 
 class ArticleCreationAPIView(APIView):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (IsAuthenticatedOrReadOnly, )
     serializer_class = ArticlesSerializer
 
     def get(self, request):
@@ -42,24 +37,19 @@ class ArticleCreationAPIView(APIView):
         serializer = self.serializer_class(data=article)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-
         res_data = Article.format_data_for_display(serializer.data)
-
         return Response(res_data, status=status.HTTP_201_CREATED)
 
 
 class GetSingleArticleAPIView(APIView):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
-    renderer_classes = (ArticleJSONRenderer,)
+    permission_classes = (IsAuthenticatedOrReadOnly, )
+    renderer_classes = (ArticleJSONRenderer, )
     serializer_class = ArticlesSerializer
 
     def get(self, request, slug):
         article = Article.get_article(slug)
-
         if not article:
-            raise exceptions.NotFound(
-                'The selected article was not found.')
-
+            raise exceptions.NotFound('The selected article was not found.')
         serializer = self.serializer_class(article)
         res_data = Article.format_data_for_display(serializer.data)
         return Response({"article": res_data}, status.HTTP_200_OK)
@@ -73,7 +63,6 @@ class GetSingleArticleAPIView(APIView):
             serializer = self.serializer_class(status[0])
             res_data = Article.format_data_for_display(serializer.data)
             return Response(res_data, 202)
-
         return Response({'message': status[0]}, status[1])
 
     def delete(self, request, slug):
@@ -88,7 +77,7 @@ class RateArticleAPIView(APIView):
     This class contains the views regarding the article
     rating feature
     """
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, )
     serializer_class = ArticlesSerializer
 
     def get_values(self, queryset):
@@ -101,8 +90,7 @@ class RateArticleAPIView(APIView):
     def validate_rating(self, rating):
         if rating not in list(range(1, 6)):
             raise exceptions.ParseError(
-                "Sorry, only a rating in the 1-5 range can be given."
-            )
+                "Sorry, only a rating in the 1-5 range can be given.")
 
     def put(self, request, slug):
         """
@@ -111,40 +99,30 @@ class RateArticleAPIView(APIView):
         """
         queryset = Article.objects.filter(slug=slug)
         article = self.get_values(queryset)
-
         if not queryset:
-            raise exceptions.NotFound(
-                'The selected article was not found.')
+            raise exceptions.NotFound('The selected article was not found.')
         elif article.get("author_id") == get_user_from_auth(request).id:
             raise exceptions.ParseError(
-                "Sorry, you cannot rate your own article."
-            )
+                "Sorry, you cannot rate your own article.")
 
         serializer_instance = queryset.first()
         serializer_data = request.data.get('article', {})
         self.validate_rating(serializer_data.get("rating"))
-
         current_rating = article['rating']
         current_rating_count = article['ratingsCount']
         user_rating = serializer_data.get('rating')
         new_rating = Article.calculate_rating(
-            current_rating,
-            current_rating_count,
-            user_rating)
-
+            current_rating, current_rating_count, user_rating)
         serializer_data["rating"] = new_rating["rating"]
         serializer_data["ratingsCount"] = new_rating["ratingsCount"]
         serializer = self.serializer_class(
-            serializer_instance,
-            data=serializer_data,
-            partial=True
-        )
+            serializer_instance, data=serializer_data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-
-        return Response(
-            {"article": serializer.data},
-            status=status.HTTP_202_ACCEPTED)
+        return Response({
+            "article": serializer.data
+        },
+                        status=status.HTTP_202_ACCEPTED)
 
 
 def get_user_from_auth(request):
@@ -158,8 +136,9 @@ def get_user_from_auth(request):
 
 
 class LikeView(CreateAPIView, UpdateAPIView):
-    permission_classes = (IsAuthenticated,)
-    renderer_classes = (LikesJSONRenderer,)
+    """like view class"""
+    permission_classes = (IsAuthenticated, )
+    renderer_classes = (LikesJSONRenderer, )
     serializer_class = LikeSerializer
 
     def create(self, request, *args, **kwargs):
@@ -173,30 +152,29 @@ class LikeView(CreateAPIView, UpdateAPIView):
             action = request.data.get('like', {})
             serializer = self.serializer_class(data=action)
             serializer.is_valid(raise_exception=True)
-            serializer.save(
-                action_by=self.request.user, article=self.article1)
-            return Response(
-                serializer.data, status=status.HTTP_201_CREATED)
+            serializer.save(action_by=self.request.user, article=self.article1)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         article1 = self.kwargs["slug"]
         article = get_object_or_404(Article, slug=article1)
         try:
-            instance = Likes.objects.get(action_by=request.user.id,
-                                         article=article.id)
+            instance = Likes.objects.get(
+                action_by=request.user.id, article=article.id)
             action = request.data.get('like', {})
-            serializer = self.serializer_class(instance,
-                                               data=action, partial=True)
+            serializer = self.serializer_class(
+                instance, data=action, partial=True)
             serializer.is_valid(raise_exception=True)
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception:
-            raise serializers.ValidationError('cannot update'
-                                              'like or dislike article', 400)
+            raise serializers.ValidationError(
+                'cannot update'
+                'like or dislike article', 400)
 
 
 class PostCommentApiView(APIView):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (IsAuthenticatedOrReadOnly, )
     serializer_class = CommentSerializer
 
     def get(self, request, slug):
@@ -219,7 +197,7 @@ class PostCommentApiView(APIView):
 
 
 class CommentDetailApiView(APIView):
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (IsAuthenticatedOrReadOnly, )
     serializer_class = CommentDetailSerializer
 
     def get(self, request, slug, id):
@@ -231,9 +209,12 @@ class CommentDetailApiView(APIView):
         return Response({"comment": new_comment}, status.HTTP_200_OK)
 
     def format_dictionary(self, item):
-        new_comment = dict(id=item["id"], body=item["body"],
-                           user=item["user"], timestamp=item["timestamp"],
-                           reply=item["replies"])
+        new_comment = dict(
+            id=item["id"],
+            body=item["body"],
+            user=item["user"],
+            timestamp=item["timestamp"],
+            reply=item["replies"])
         return new_comment
 
     def post(self, request, slug, id):

--- a/authors/apps/articles/views_favourites.py
+++ b/authors/apps/articles/views_favourites.py
@@ -1,0 +1,72 @@
+from rest_framework import status, serializers, exceptions
+from rest_framework.permissions import (IsAuthenticatedOrReadOnly,
+                                        IsAuthenticated)
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.shortcuts import get_object_or_404
+from rest_framework.generics import (CreateAPIView, RetrieveAPIView)
+from .renderers import LikesJSONRenderer
+from .serializers import (FavouriteSerializer, GetFavouriteSerializer)
+from django.shortcuts import get_object_or_404
+from .models import Article, Comment, Likes, Favourite
+
+
+class GetFavouriteView(RetrieveAPIView):
+    """This class handles getting favourite articles"""
+
+    permission_classes = (IsAuthenticated, )
+    renderer_classes = (LikesJSONRenderer, )
+    serializer_class = GetFavouriteSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        data1 = Favourite.objects.all().prefetch_related('article').filter(
+            user=request.user.id)
+        serializer = self.serializer_class(data1, many=True)
+        return Response({
+            "favourites": serializer.data
+        },
+                        status=status.HTTP_200_OK)
+
+
+class FavouriteView(APIView):
+    """This class handles favourating and unfavourating articles"""
+
+    permission_classes = (IsAuthenticated, )
+    renderer_classes = (LikesJSONRenderer, )
+    serializer_class = FavouriteSerializer
+
+    def post(self, request, slug):
+        """This method adds an article to favourites"""
+        article = get_object_or_404(Article, slug=slug)
+        if Favourite.objects.filter(
+                user=request.user, article=article).exists():
+            raise serializers.ValidationError(
+                "You have already favourited " + "this article", 400)
+        else:
+            request.data["user"] = request.user.id
+            request.data["article"] = article
+            serializer = self.serializer_class(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save(user=self.request.user, article=article)
+            return Response(
+                {
+                    "message": "Article successfully " + "added to favorites"
+                },
+                status=status.HTTP_201_CREATED)
+
+    def delete(self, request, slug):
+        """This method deletes an article from favourites"""
+        article = get_object_or_404(Article, slug=slug)
+        try:
+            instance = Favourite.objects.get(
+                user=request.user.id, article=article.id)
+            instance.delete()
+            return Response({
+                "status": "successfully removed from favourites"
+            },
+                            status=status.HTTP_200_OK)
+        except Exception:
+            return Response({
+                "error": "Article not in favourite list"
+            },
+                            status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
**What does this PR do**
Users are able to favourite and unfavourite articles as well as getting their favourite articles
**Description**

Every authenticated user can favourite an article that they find appealing. They can also unfavourite that article. Once a user favourites articles, they can access all their favourite articles.

**How to test this manually**
Get an article slug and put it into the favourite article route 
http://127.0.0.1:8000/api/articles/slug-here/favourite/ have the method set to post then send the request.This will successfully add the article to favourites.To unfavourite an article, use the same url with the slug set the method to delete and remove that article from favourites.
 To get your favourite articles use the endpoint.
http://127.0.0.1:8000/api/articles/favourites/ 

**screen shot**
**Adding to favourites**
<img width="1034" alt="screen shot 2018-10-18 at 08 09 43" src="https://user-images.githubusercontent.com/40117122/47133276-bbb3cd00-d2b0-11e8-9888-627bc68b843b.png">

**unfavouriting articles**

<img width="1114" alt="screen shot 2018-10-18 at 08 10 12" src="https://user-images.githubusercontent.com/40117122/47133284-c9695280-d2b0-11e8-923d-467fc3175f4e.png">
**Getting all favourites**
<img width="967" alt="screen shot 2018-10-18 at 08 10 26" src="https://user-images.githubusercontent.com/40117122/47133314-e69e2100-d2b0-11e8-928e-0188080ca4ae.png">
 