### PR TITLE
#160584010 Add search for articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,10 @@ var/
 # Django Migrations
 migrations/
 authors/apps/articles/migrations
+*/migrations/*
 authors/apps/authentication/migrations/*
+authors/apps/articles/migrations/*
+authors/apps/profiles/migrations/*
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: gunicorn authors.wsgi --log-file -
-release: python manage.py makemigrations authentication; python manage.py makemigrations profiles; python manage.py makemigrations articles; python manage.py migrate;
+release: python manage.py makemigrations authentication;python manage.py makemigrations profiles;python manage.py makemigrations articles;python manage.py migrate

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -59,6 +59,15 @@ class Article(models.Model):
 
         return unique_slug
 
+    @property
+    def tags(self):
+        items = literal_eval(self.tagList)
+        print(type(items))
+        if isinstance(items, list):
+            return items
+        else:
+            return []
+
     @staticmethod
     def title_exists(user_id, title):
         return Article.objects.filter(

--- a/authors/apps/articles/tests/test_article.py
+++ b/authors/apps/articles/tests/test_article.py
@@ -281,3 +281,65 @@ class TestArticle(BaseTest):
             "/api/articles/titlely/favourite/", format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         assert "error" in response.data
+
+    def test_search_article_by_author(self):
+        # create two articles using one user
+        self.mock_login()
+        self.create_article(self.article_1)
+        self.create_article(self.article_2)
+        # create two more article with a different user
+        self.different_user_mock_login()
+        self.create_article(self.article_3)
+        self.create_article(self.article_4)
+        author = self.reg_data.get('user')['username']
+        # get the articles of the first user
+        response = self.client.get(
+            '/api/articles/search/?author={}'.format(author))
+        self.assertEqual(len(response.data['search results']), 2)
+        self.assertEqual(response.status_code, 200)
+
+    def test_search_article_by_title(self):
+        # create two articles using one user
+        self.mock_login()
+        self.create_article(self.article_1)
+        self.create_article(self.article_2)
+        self.create_article(self.article_3)
+        title = self.article_2.get('article')['title']
+        response = self.client.get(
+            '/api/articles/search/?title={}'.format(title))
+        self.assertEqual(len(response.data['search results']), 1)
+        self.assertIn(title, str(response.data))
+
+    def test_search_article_by_tag(self):
+        self.mock_login()
+        self.create_article(self.article_1)
+        self.create_article(self.article_2)
+        response = self.client.get('/api/articles/search/?tag=Health')
+        self.assertEqual(len(response.data['search results']), 1)
+        self.assertEqual(response.status_code, 200)
+
+    def test_search_article_by_keywords(self):
+        self.mock_login()
+        self.create_article(self.article_1)
+        self.create_article(self.article_2)
+        self.create_article(self.article_3)
+
+        response = self.client.get('/api/articles/search/?keywords=title')
+        self.assertEqual(len(response.data['search results']), 2)
+        self.assertEqual(response.status_code, 200)
+
+    def search_article_with_all_parameters(self):
+        # create two articles using one user
+        self.mock_login()
+        self.create_article(self.article_1)
+        self.create_article(self.article_2)
+        self.create_article(self.article_3)
+        self.create_article(self.article_4)
+        author = self.reg_data.get('user')['username']
+        tag = 'Hello'
+        keywords = 'let,see'
+        response = self.client.get(
+            '/api/articles/search/?author={}&tag={}&keywords={}'.format(
+                author, tag, keywords))
+        self.assertEqual(len(response.data['search results']), 1)
+        self.assertEqual(response.status_code, 200)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from .views import (ArticleCreationAPIView, GetSingleArticleAPIView,
                     PostCommentApiView, CommentDetailApiView,
-                    RateArticleAPIView, LikeView)
+                    RateArticleAPIView, LikeView, SearchArticleView)
 from .views_favourites import (FavouriteView, GetFavouriteView)
 urlpatterns = [
     path('articles/', ArticleCreationAPIView.as_view()),
@@ -14,4 +14,5 @@ urlpatterns = [
     path('articles/<str:slug>/like/', LikeView.as_view()),
     path('articles/<str:slug>/favourite/', FavouriteView.as_view()),
     path('articles/favourites/', GetFavouriteView.as_view()),
+    path('articles/search/', SearchArticleView.as_view()),
 ]

--- a/authors/apps/authentication/tests/__init__.py
+++ b/authors/apps/authentication/tests/__init__.py
@@ -147,6 +147,24 @@ class BaseTest(TestCase):
             }
         }
 
+        self.article_3 = {
+            "article": {
+                "title": "title 3",
+                "description": "description 4?",
+                "body": "body",
+                "tagList": ["medium", "bold"]
+            }
+        }
+
+        self.article_4 = {
+            "article": {
+                "title": "my story",
+                "description": "Describe?",
+                "body": "La body",
+                "tagList": ["Hello", "Hmm"]
+            }
+        }
+
         self.invalid_article = {
             "article": {
                 "title": "title me",
@@ -173,14 +191,13 @@ class BaseTest(TestCase):
         self.comment1 = {"comment": {"body": "something else"}}
         # Test the article model functions
         self.article = Article.objects.create(
-            title="my title",
+            title="lego",
             description='my description',
             body='my body',
             author=self.user)
-
         self.article.save()
         # update the article
-        Article.update_article(self.user.id, 'my-title', self.article_2)
+        Article.update_article(self.user.id, 'lego', self.article_2)
         # check whether the modified article exists via new slug
         Article.article_exists('let-me-see')
         test_data = Article.get_article('let-me-see')
@@ -236,3 +253,6 @@ class BaseTest(TestCase):
             '/api/articles/titlely/comments/',
             data=self.comment1,
             format="json")
+
+    def create_article(self, article):
+        self.client.post('/api/articles/', article, format="json")


### PR DESCRIPTION
### What does this PR do?
It adds search for articles

### Description of the tasks to be completed.
A user should be able to filter articles by author
A user should be able to filter articles by tag
A user should be able to filter by keywords
A user should be able to combine all the above search criteria to filter articles

### How can this be manually tested?
```
git checkout ft-add-article-search-160584010
python manage.py makemigrations authentication
python manage.py makemigrations profiles
python manage.py makemigrations articles
python manage.py migrate
python manage.py runserver
```
### Screenshots
<img width="1552" alt="search_by_author" src="https://user-images.githubusercontent.com/38511070/47198180-7ad0bc80-d373-11e8-957e-a3064a35b80d.png">

<img width="1552" alt="search_by_tag" src="https://user-images.githubusercontent.com/38511070/47198198-9045e680-d373-11e8-9de5-03d559f89e4a.png">

<img width="1552" alt="search_by_keywords" src="https://user-images.githubusercontent.com/38511070/47198214-a0f65c80-d373-11e8-9397-a599c58863c7.png">

Pivotal Tracker ID:
#160584010
