### PR TITLE
Articles should have author's name

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -8,6 +8,8 @@ class ArticlesSerializer(serializers.ModelSerializer):
     """
     Handles the serialization and deserialization of Article objects
     """
+    author_name = serializers.CharField(source='author.username',
+                                        required=False)
 
     def create(self, validated_data):
         """
@@ -19,7 +21,8 @@ class ArticlesSerializer(serializers.ModelSerializer):
         model = Article
         fields = ("slug", "title", "description", "body", "image", "tagList",
                   "createdAt", "updatedAt", "favoritesCount", "rating",
-                  "ratingsCount", "author", "likes", "dislikes")
+                  "ratingsCount", "author", "author_name", "likes", "dislikes")
+        read_only_fields = ('author_name', )
 
     @staticmethod
     def convert_tagList_to_str(request_data={}):


### PR DESCRIPTION
**What does this PR do?**
This PR enables articles to have the author's name.

**Description of the task to be completed**
currently, created articles do not show the author's name. This has become quite a challenge because the username is essential while sending out some requests.

**How should this be manually tested**
- after cloning the repo, checkout into this branch
- create a virtual environment and install the requirements
- start the server
- visit this endpoint http://localhost:8000/api/articles/ on postman.
-You will see that every article shows the name of the author.

**Relevant Pivotal Tracker Stories**

 [#162149814](https://www.pivotaltracker.com/n/projects/2198584/stories/162149814)

Any background context you want to add?
N/A

Screen shots

<img width="911" alt="screen shot 2018-11-22 at 12 03 43" src="https://user-images.githubusercontent.com/40117122/48892258-b9640600-ee4e-11e8-890c-8819c2d4fbb6.png">
